### PR TITLE
update unioffice to v2

### DIFF
--- a/document/bullet-and-numbering/main.go
+++ b/document/bullet-and-numbering/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/chart/main.go
+++ b/document/chart/main.go
@@ -9,17 +9,17 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
+	"github.com/unidoc/unioffice/v2/common/license"
 	unipdflicense "github.com/unidoc/unipdf/v3/common/license"
 
 	"github.com/disintegration/imaging"
 	"github.com/unidoc/unichart"
 	"github.com/unidoc/unichart/dataset"
 
-	"github.com/unidoc/unioffice/common"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 
 	"github.com/unidoc/unipdf/v3/creator"
 	"github.com/unidoc/unipdf/v3/model"

--- a/document/convert_to_pdf/main.go
+++ b/document/convert_to_pdf/main.go
@@ -11,9 +11,9 @@ import (
 
 	unipdflicense "github.com/unidoc/unipdf/v3/common/license"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/document/convert"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/document/convert"
 )
 
 func init() {

--- a/document/convert_to_pdf_fonts/main.go
+++ b/document/convert_to_pdf_fonts/main.go
@@ -12,9 +12,9 @@ import (
 	unipdflicense "github.com/unidoc/unipdf/v3/common/license"
 	"github.com/unidoc/unipdf/v3/model"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/document/convert"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/document/convert"
 )
 
 func init() {

--- a/document/convert_to_pdf_options/main.go
+++ b/document/convert_to_pdf_options/main.go
@@ -11,9 +11,9 @@ import (
 
 	unipdflicense "github.com/unidoc/unipdf/v3/common/license"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/document/convert"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/document/convert"
 )
 
 func init() {

--- a/document/doc-custom-properties/main.go
+++ b/document/doc-custom-properties/main.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {
@@ -31,15 +31,15 @@ func main() {
 	cp := doc.GetOrCreateCustomProperties()
 
 	// You can read properties from the document
-	fmt.Println("AppVersion", *cp.GetPropertyByName("AppVersion").X().Lpwstr)
-	fmt.Println("Company", *cp.GetPropertyByName("Company").X().Lpwstr)
-	fmt.Println("DocSecurity", *cp.GetPropertyByName("DocSecurity").X().I4)
-	fmt.Println("LinksUpToDate", *cp.GetPropertyByName("LinksUpToDate").X().Bool)
+	fmt.Println("AppVersion", *cp.GetPropertyByName("AppVersion").X().PropertyChoice.Lpwstr)
+	fmt.Println("Company", *cp.GetPropertyByName("Company").X().PropertyChoice.Lpwstr)
+	fmt.Println("DocSecurity", *cp.GetPropertyByName("DocSecurity").X().PropertyChoice.I4)
+	fmt.Println("LinksUpToDate", *cp.GetPropertyByName("LinksUpToDate").X().PropertyChoice.Bool)
 	fmt.Println("Non-existent", cp.GetPropertyByName("nonexistentproperty"))
 
 	// And change them as well
 	cp.SetPropertyAsLpwstr("Company", "Another company") // text, existing property
-	fmt.Println("Company", *cp.GetPropertyByName("Company").X().Lpwstr)
+	fmt.Println("Company", *cp.GetPropertyByName("Company").X().PropertyChoice.Lpwstr)
 
 	// Adding new properties
 	cp.SetPropertyAsLpwstr("Another text property", "My text value") // text

--- a/document/doc-existing-header/main.go
+++ b/document/doc-existing-header/main.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/doc-properties/main.go
+++ b/document/doc-properties/main.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/doc-to-pdf-fonts/main.go
+++ b/document/doc-to-pdf-fonts/main.go
@@ -12,9 +12,9 @@ import (
 	unipdflicense "github.com/unidoc/unipdf/v3/common/license"
 	"github.com/unidoc/unipdf/v3/model"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/document/convert"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/document/convert"
 )
 
 func init() {

--- a/document/doc-to-pdf/main.go
+++ b/document/doc-to-pdf/main.go
@@ -11,9 +11,9 @@ import (
 
 	unipdflicense "github.com/unidoc/unipdf/v3/common/license"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/document/convert"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/document/convert"
 )
 
 func init() {

--- a/document/edit-document/main.go
+++ b/document/edit-document/main.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/endnotes_footnotes/main.go
+++ b/document/endnotes_footnotes/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/endnotes_footnotes_insert/main.go
+++ b/document/endnotes_footnotes_insert/main.go
@@ -3,19 +3,17 @@
 package main
 
 import (
+	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
 )
 
 func init() {
-	// Make sure to load your metered License API key prior to using the library.
-	// If you need a key, you can sign up and create a free one at https://cloud.unidoc.io
-	err := license.SetMeteredKey(os.Getenv(`UNIDOC_LICENSE_API_KEY`))
-	if err != nil {
-		panic(err)
+	if err := license.SetMeteredKey(os.Getenv("UNIDOC_LICENSE_API_KEY")); err != nil {
+		log.Fatalf("error: %s", err)
 	}
 }
 

--- a/document/endnotes_footnotes_remove/main.go
+++ b/document/endnotes_footnotes_remove/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/even-odd-header/main.go
+++ b/document/even-odd-header/main.go
@@ -9,10 +9,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/schema/soo/ofc/sharedTypes"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/schema/soo/ofc/sharedTypes"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/fill-out-form/main.go
+++ b/document/fill-out-form/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/form-activex/main.go
+++ b/document/form-activex/main.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/form-fields/main.go
+++ b/document/form-fields/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/header-footer-multiple/main.go
+++ b/document/header-footer-multiple/main.go
@@ -4,10 +4,10 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/header-footer/main.go
+++ b/document/header-footer/main.go
@@ -6,11 +6,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/hyperlink/main.go
+++ b/document/hyperlink/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/image-text-wrap/main.go
+++ b/document/image-text-wrap/main.go
@@ -6,12 +6,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
+	"github.com/unidoc/unioffice/v2/common"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
 
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/image/main.go
+++ b/document/image/main.go
@@ -6,12 +6,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
+	"github.com/unidoc/unioffice/v2/common"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
 
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/line-spacing/main.go
+++ b/document/line-spacing/main.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/mail-merge/main.go
+++ b/document/mail-merge/main.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/merge-documents/main.go
+++ b/document/merge-documents/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/node-combine/main.go
+++ b/document/node-combine/main.go
@@ -15,8 +15,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/node-extraction/main.go
+++ b/document/node-extraction/main.go
@@ -15,8 +15,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/node-find-and-replace/main.go
+++ b/document/node-find-and-replace/main.go
@@ -14,8 +14,8 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/node-remove/main.go
+++ b/document/node-remove/main.go
@@ -5,11 +5,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/unidoc/unioffice/document"
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/node-selection/main.go
+++ b/document/node-selection/main.go
@@ -14,8 +14,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/number-of-pages/main.go
+++ b/document/number-of-pages/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/page-numbers/main.go
+++ b/document/page-numbers/main.go
@@ -4,10 +4,10 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/page-size-and-orientation/main.go
+++ b/document/page-size-and-orientation/main.go
@@ -4,10 +4,10 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/paragraph-borders/main.go
+++ b/document/paragraph-borders/main.go
@@ -14,11 +14,11 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/paragraph-rtl/main.go
+++ b/document/paragraph-rtl/main.go
@@ -5,10 +5,10 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/paragraph-style/main.go
+++ b/document/paragraph-style/main.go
@@ -4,10 +4,10 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/paragraph_spacing_and_indentation/main.go
+++ b/document/paragraph_spacing_and_indentation/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/paragraphs_in_table/main.go
+++ b/document/paragraphs_in_table/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/pdf-export-ole/main.go
+++ b/document/pdf-export-ole/main.go
@@ -8,8 +8,9 @@ import (
 
 	ole "github.com/go-ole/go-ole"
 	"github.com/go-ole/go-ole/oleutil"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/run-properties/main.go
+++ b/document/run-properties/main.go
@@ -7,9 +7,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {
@@ -31,32 +31,53 @@ func main() {
 		for _, r := range p.Runs() {
 			for _, any := range r.X().Extra {
 				if ac, ok := any.(*wml.AlternateContentRun); ok {
-					for _, anchor := range ac.Choice.Drawing.Anchor {
-						for _, any := range anchor.Graphic.GraphicData.Any {
-							if wps, ok := any.(*wml.WdWsp); ok {
-								if wps.WChoice != nil {
-									fmt.Println("")
-									fmt.Println("")
-									for _, egcbc := range wps.WChoice.Txbx.TxbxContent.EG_ContentBlockContent {
-										for _, p := range egcbc.P {
+					if ch := ac.Choice.Drawing; ch != nil {
+						for _, dc := range ch.DrawingChoice {
+							if anchor := dc.Anchor; anchor != nil {
+								for _, any := range anchor.Graphic.GraphicData.Any {
+									if wps, ok := any.(*wml.WdWsp); ok {
+										if wps.WordprocessingShapeChoice1 != nil {
 											fmt.Println("")
-											for i, egpc := range p.EG_PContent {
-												fmt.Println(i)
-												for _, egcrc := range egpc.EG_ContentRunContent {
-													run := egcrc.R
-													for _, egric := range run.EG_RunInnerContent {
-														if egric.T != nil {
-															fmt.Println(egric.T.Content)
-														}
-													}
-												}
-												if hyperlink := egpc.Hyperlink; hyperlink != nil {
-													fmt.Println("Hyperlink:")
-													for _, egcrc := range hyperlink.EG_ContentRunContent {
-														run := egcrc.R
-														for _, egric := range run.EG_RunInnerContent {
-															if egric.T != nil {
-																fmt.Println(egric.T.Content)
+											fmt.Println("")
+											for _, egcbc := range wps.WordprocessingShapeChoice1.Txbx.TxbxContent.EG_BlockLevelElts {
+												if blc := egcbc.BlockLevelEltsChoice; blc != nil {
+													for _, cbc := range blc.EG_ContentBlockContent {
+														if cbc.ContentBlockContentChoice != nil {
+															for _, p := range cbc.ContentBlockContentChoice.P {
+																for i, egpc := range p.EG_PContent {
+																	fmt.Println(i)
+																	if pcc := egpc.PContentChoice; pcc != nil {
+																		for _, egcrc := range pcc.EG_ContentRunContent {
+																			if egcrc.ContentRunContentChoice != nil {
+																				run := egcrc.ContentRunContentChoice.R
+																				for _, egric := range run.EG_RunInnerContent {
+																					if egric.RunInnerContentChoice != nil {
+																						if egric.RunInnerContentChoice.T != nil {
+																							fmt.Println(egric.RunInnerContentChoice.T.Content)
+																						}
+																					}
+																				}
+																			}
+																		}
+																		if hyperlink := pcc.Hyperlink; hyperlink != nil {
+																			fmt.Println("Hyperlink:")
+																			if hyperlink.PContentChoice != nil {
+																				for _, egcrc := range hyperlink.PContentChoice.EG_ContentRunContent {
+																					if egcrc.ContentRunContentChoice != nil {
+																						run := egcrc.ContentRunContentChoice.R
+																						for _, egric := range run.EG_RunInnerContent {
+																							if egric.RunInnerContentChoice != nil {
+																								if egric.RunInnerContentChoice.T != nil {
+																									fmt.Println(egric.RunInnerContentChoice.T.Content)
+																								}
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
 															}
 														}
 													}

--- a/document/set-strict/main.go
+++ b/document/set-strict/main.go
@@ -5,8 +5,8 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/simple/main.go
+++ b/document/simple/main.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/table-row-cant-split/main.go
+++ b/document/table-row-cant-split/main.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
 
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/tables/main.go
+++ b/document/tables/main.go
@@ -6,12 +6,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
 
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/template-with-header/main.go
+++ b/document/template-with-header/main.go
@@ -10,9 +10,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/text_extraction/main.go
+++ b/document/text_extraction/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
 )
 
 func init() {

--- a/document/text_extraction_with_numbering/main.go
+++ b/document/text_extraction_with_numbering/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
 )
 
 func init() {

--- a/document/toc-custom/main.go
+++ b/document/toc-custom/main.go
@@ -4,10 +4,10 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {

--- a/document/toc-generation-ole/main.go
+++ b/document/toc-generation-ole/main.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 
 	ole "github.com/go-ole/go-ole"
 	"github.com/go-ole/go-ole/oleutil"

--- a/document/toc/main.go
+++ b/document/toc/main.go
@@ -4,10 +4,10 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/wml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/wml"
 )
 
 func init() {
@@ -29,7 +29,7 @@ func main() {
 	doc.Settings.SetUpdateFieldsOnOpen(true)
 
 	// Add a TOC
-	doc.AddParagraph().AddRun().AddTOC(nil)
+	doc.AddParagraph().AddRun().AddField(document.FieldTOC)
 	// followed by a page break
 	doc.AddParagraph().Properties().AddSection(wml.ST_SectionMarkNextPage)
 

--- a/document/use-template/main.go
+++ b/document/use-template/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/document/watermark-picture/main.go
+++ b/document/watermark-picture/main.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
-	"github.com/unidoc/unioffice/measurement"
+	"github.com/unidoc/unioffice/v2/common"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
+	"github.com/unidoc/unioffice/v2/measurement"
 )
 
 func init() {

--- a/document/watermark-text/main.go
+++ b/document/watermark-text/main.go
@@ -4,8 +4,8 @@ package main
 import (
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/unidoc/unioffice-examples
 
-go 1.18
+go 1.19
 
 require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/go-ole/go-ole v1.3.0
 	github.com/unidoc/unichart v0.3.0
-	github.com/unidoc/unioffice v1.39.0
+	github.com/unidoc/unioffice/v2 v2.0.0
 	github.com/unidoc/unipdf/v3 v3.66.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/unidoc/timestamp v0.0.0-20200412005513-91597fd3793a h1:RLtvUhe4DsUDl6
 github.com/unidoc/timestamp v0.0.0-20200412005513-91597fd3793a/go.mod h1:j+qMWZVpZFTvDey3zxUkSgPJZEX33tDgU/QIA0IzCUw=
 github.com/unidoc/unichart v0.3.0 h1:VX1j5yzhjrR3f2flC03Yat6/WF3h7Z+DLEvJLoTGhoc=
 github.com/unidoc/unichart v0.3.0/go.mod h1:8JnLNKSOl8yQt1jXewNgYFHhFm5M6/ZiaydncFDpakA=
-github.com/unidoc/unioffice v1.39.0 h1:Wo5zvrzCqhyK/1Zi5dg8a5F5+NRftIMZPnFPYwruLto=
-github.com/unidoc/unioffice v1.39.0/go.mod h1:Axz6ltIZZTUUyHoEnPe4Mb3VmsN4TRHT5iZCGZ1rgnU=
+github.com/unidoc/unioffice/v2 v2.0.0 h1:AI4LxJ2DRphfuNLB5ezChUMTDKHTpO6SbO37nrdYWMM=
+github.com/unidoc/unioffice/v2 v2.0.0/go.mod h1:dUugJ94ApprtyRU61dc8F2+gCoKfcb9z43wREihIN5k=
 github.com/unidoc/unipdf/v3 v3.66.0 h1:P7E58stKD1oQiZLUEzRDZ9s2pGmESKG8Lj+j+/BhUP4=
 github.com/unidoc/unipdf/v3 v3.66.0/go.mod h1:ZdluVnF2Yhr/brmTmY2NxHC/ocZGf5IQrw/IDgox0eU=
 github.com/unidoc/unitype v0.4.0 h1:/TMZ3wgwfWWX64mU5x2O9no9UmoBqYCB089LYYqHyQQ=

--- a/license/metered-non-persistent-cache/main.go
+++ b/license/metered-non-persistent-cache/main.go
@@ -11,7 +11,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/unidoc/unioffice/common/license"
+	"github.com/unidoc/unioffice/v2/common/license"
 )
 
 func init() {

--- a/license/metered/main.go
+++ b/license/metered/main.go
@@ -11,7 +11,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/unidoc/unioffice/common/license"
+	"github.com/unidoc/unioffice/v2/common/license"
 )
 
 func init() {

--- a/license/offline/main.go
+++ b/license/offline/main.go
@@ -11,7 +11,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/unidoc/unioffice/common/license"
+	"github.com/unidoc/unioffice/v2/common/license"
 )
 
 // Example of an offline perpetual license key.

--- a/license/usage-logs/main.go
+++ b/license/usage-logs/main.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/common/logger"
-	"github.com/unidoc/unioffice/document"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/common/logger"
+	"github.com/unidoc/unioffice/v2/document"
 )
 
 func init() {

--- a/presentation/chart/main.go
+++ b/presentation/chart/main.go
@@ -10,17 +10,18 @@ import (
 	"os"
 
 	"github.com/disintegration/imaging"
+
 	"github.com/unidoc/unichart"
 	"github.com/unidoc/unichart/dataset"
-	"github.com/unidoc/unioffice/common/license"
 	unipdflicense "github.com/unidoc/unipdf/v3/common/license"
 	"github.com/unidoc/unipdf/v3/creator"
 	"github.com/unidoc/unipdf/v3/model"
 	"github.com/unidoc/unipdf/v3/render"
 
-	"github.com/unidoc/unioffice/common"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/presentation"
+	"github.com/unidoc/unioffice/v2/common"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/presentation"
 )
 
 func init() {

--- a/presentation/complex/main.go
+++ b/presentation/complex/main.go
@@ -5,13 +5,13 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/schema/soo/dml"
+	"github.com/unidoc/unioffice/v2/schema/soo/dml"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/presentation"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/presentation"
 )
 
 func init() {

--- a/presentation/convert_to_pdf/main.go
+++ b/presentation/convert_to_pdf/main.go
@@ -12,9 +12,9 @@ import (
 
 	unipdflicense "github.com/unidoc/unipdf/v3/common/license"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/presentation"
-	"github.com/unidoc/unioffice/presentation/convert"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/presentation"
+	"github.com/unidoc/unioffice/v2/presentation/convert"
 )
 
 func init() {

--- a/presentation/copy-reorder-slide/main.go
+++ b/presentation/copy-reorder-slide/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/presentation"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/presentation"
 )
 
 func init() {

--- a/presentation/image/main.go
+++ b/presentation/image/main.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/presentation"
+	"github.com/unidoc/unioffice/v2/common"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/presentation"
 )
 
 func init() {

--- a/presentation/placeholder-add-table/main.go
+++ b/presentation/placeholder-add-table/main.go
@@ -6,11 +6,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/presentation"
-	"github.com/unidoc/unioffice/schema/soo/dml"
-	"github.com/unidoc/unioffice/schema/soo/pml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/presentation"
+	"github.com/unidoc/unioffice/v2/schema/soo/dml"
+	"github.com/unidoc/unioffice/v2/schema/soo/pml"
 )
 
 func init() {
@@ -52,18 +52,18 @@ func main() {
 
 						egtr := dml.NewEG_TextRun()
 						para.EG_TextRun = append(para.EG_TextRun, egtr)
-						egtr.R = dml.NewCT_RegularTextRun()
-						egtr.R.T = fmt.Sprintf("Cell %d:%d", ri, ci)
+						egtr.TextRunChoice.R = dml.NewCT_RegularTextRun()
+						egtr.TextRunChoice.R.T = fmt.Sprintf("Cell %d:%d", ri, ci)
 					}
 				}
 
 				style := dml.NewCT_TableStyle()
 				style.WholeTbl = dml.NewCT_TablePartStyle()
 				tcStyle := dml.NewCT_TableStyleCellStyle()
-				tcStyle.Fill = dml.NewCT_FillProperties()
-				tcStyle.Fill.SolidFill = dml.NewCT_SolidColorFillProperties()
-				tcStyle.Fill.SolidFill.SrgbClr = dml.NewCT_SRgbColor()
-				tcStyle.Fill.SolidFill.SrgbClr.ValAttr = "FF9900"
+				tcStyle.ThemeableFillStyleChoice.Fill = dml.NewCT_FillProperties()
+				tcStyle.ThemeableFillStyleChoice.Fill.FillPropertiesChoice.SolidFill = dml.NewCT_SolidColorFillProperties()
+				tcStyle.ThemeableFillStyleChoice.Fill.FillPropertiesChoice.SolidFill.SrgbClr = dml.NewCT_SRgbColor()
+				tcStyle.ThemeableFillStyleChoice.Fill.FillPropertiesChoice.SolidFill.SrgbClr.ValAttr = "FF9900"
 				style.WholeTbl.TcStyle = tcStyle
 				tbl.SetStyle(style)
 

--- a/presentation/simple/main.go
+++ b/presentation/simple/main.go
@@ -5,12 +5,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/schema/soo/dml"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/schema/soo/dml"
 
-	"github.com/unidoc/unioffice/presentation"
+	"github.com/unidoc/unioffice/v2/presentation"
 )
 
 func init() {

--- a/presentation/slide-size/main.go
+++ b/presentation/slide-size/main.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/presentation"
-	"github.com/unidoc/unioffice/schema/soo/dml"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/presentation"
+	"github.com/unidoc/unioffice/v2/schema/soo/dml"
 )
 
 func init() {

--- a/presentation/tables/main.go
+++ b/presentation/tables/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/presentation"
-	"github.com/unidoc/unioffice/schema/soo/dml"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/presentation"
+	"github.com/unidoc/unioffice/v2/schema/soo/dml"
 )
 
 func init() {
@@ -41,18 +41,18 @@ func main() {
 
 			egtr := dml.NewEG_TextRun()
 			para.EG_TextRun = append(para.EG_TextRun, egtr)
-			egtr.R = dml.NewCT_RegularTextRun()
-			egtr.R.T = fmt.Sprintf("Cell %d:%d", ri, ci)
+			egtr.TextRunChoice.R = dml.NewCT_RegularTextRun()
+			egtr.TextRunChoice.R.T = fmt.Sprintf("Cell %d:%d", ri, ci)
 		}
 	}
 
 	style := dml.NewCT_TableStyle()
 	style.WholeTbl = dml.NewCT_TablePartStyle()
 	tcStyle := dml.NewCT_TableStyleCellStyle()
-	tcStyle.Fill = dml.NewCT_FillProperties()
-	tcStyle.Fill.SolidFill = dml.NewCT_SolidColorFillProperties()
-	tcStyle.Fill.SolidFill.SrgbClr = dml.NewCT_SRgbColor()
-	tcStyle.Fill.SolidFill.SrgbClr.ValAttr = "FF9900"
+	tcStyle.ThemeableFillStyleChoice.Fill = dml.NewCT_FillProperties()
+	tcStyle.ThemeableFillStyleChoice.Fill.FillPropertiesChoice.SolidFill = dml.NewCT_SolidColorFillProperties()
+	tcStyle.ThemeableFillStyleChoice.Fill.FillPropertiesChoice.SolidFill.SrgbClr = dml.NewCT_SRgbColor()
+	tcStyle.ThemeableFillStyleChoice.Fill.FillPropertiesChoice.SolidFill.SrgbClr.ValAttr = "FF9900"
 	style.WholeTbl.TcStyle = tcStyle
 	tbl.SetStyle(style)
 

--- a/presentation/text_extraction/main.go
+++ b/presentation/text_extraction/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/presentation"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/presentation"
 )
 
 func init() {
@@ -40,8 +40,8 @@ func main() {
 			if runProps.SzAttr != nil {
 				fmt.Println("Font size:", *runProps.SzAttr/100)
 			}
-			if runProps.SolidFill != nil && runProps.SolidFill.SchemeClr != nil {
-				fmt.Println("SolidFill:", runProps.SolidFill.SchemeClr.ValAttr)
+			if runProps.FillPropertiesChoice.SolidFill != nil && runProps.FillPropertiesChoice.SolidFill.SchemeClr != nil {
+				fmt.Println("SolidFill:", runProps.FillPropertiesChoice.SolidFill.SchemeClr.ValAttr)
 			}
 			if tblInfo := item.TableInfo; tblInfo != nil {
 				fmt.Println("Row:", tblInfo.RowIndex)

--- a/presentation/textbox/main.go
+++ b/presentation/textbox/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/presentation"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/presentation"
 )
 
 func init() {
@@ -33,15 +33,15 @@ func main() {
 	for _, tb := range tbs {
 		for _, p := range tb.X().TxBody.P {
 			for _, tr := range p.EG_TextRun {
-				fmt.Println(tr.R.T)
+				fmt.Println(tr.TextRunChoice.R.T)
 			}
 		}
 	}
 
 	// Editing the existing text box
-	tb := tbs[0]                              // taking first of them
-	run := tb.X().TxBody.P[0].EG_TextRun[0].R // taking the first run of the first paragraph
-	run.T = "Edited TextBox text"             // changing the text of the run
+	tb := tbs[0]                                            // taking first of them
+	run := tb.X().TxBody.P[0].EG_TextRun[0].TextRunChoice.R // taking the first run of the first paragraph
+	run.T = "Edited TextBox text"                           // changing the text of the run
 
 	// creating a new text box
 	newTb := slide.AddTextBox()

--- a/presentation/use-template-with-image/main.go
+++ b/presentation/use-template-with-image/main.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/unidoc/unioffice/common"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/schema/soo/dml"
-	"github.com/unidoc/unioffice/schema/soo/pml"
+	"github.com/unidoc/unioffice/v2/common"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/schema/soo/dml"
+	"github.com/unidoc/unioffice/v2/schema/soo/pml"
 
-	"github.com/unidoc/unioffice/presentation"
+	"github.com/unidoc/unioffice/v2/presentation"
 )
 
 func init() {
@@ -84,10 +84,10 @@ func main() {
 	}
 
 	spPr := dml.NewCT_ShapeProperties()
-	spPr.BlipFill = dml.NewCT_BlipFillProperties()
-	spPr.BlipFill.Blip = dml.NewCT_Blip()
-	spPr.BlipFill.Blip.EmbedAttr = &imageRelID
-	spPr.BlipFill.Stretch = dml.NewCT_StretchInfoProperties() // stretch to parent block with default values
+	spPr.FillPropertiesChoice.BlipFill = dml.NewCT_BlipFillProperties()
+	spPr.FillPropertiesChoice.BlipFill.Blip = dml.NewCT_Blip()
+	spPr.FillPropertiesChoice.BlipFill.Blip.EmbedAttr = &imageRelID
+	spPr.FillPropertiesChoice.BlipFill.FillModePropertiesChoice.Stretch = dml.NewCT_StretchInfoProperties() // stretch to parent block with default values
 
 	pic.X().SpPr = spPr
 

--- a/presentation/use-template/main.go
+++ b/presentation/use-template/main.go
@@ -6,11 +6,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/schema/soo/pml"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/schema/soo/pml"
 
-	"github.com/unidoc/unioffice/presentation"
+	"github.com/unidoc/unioffice/v2/presentation"
 )
 
 func init() {

--- a/spreadsheet/bar-chart/main.go
+++ b/spreadsheet/bar-chart/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/borders/main.go
+++ b/spreadsheet/borders/main.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/schema/soo/sml"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/schema/soo/sml"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/bubble-chart/main.go
+++ b/spreadsheet/bubble-chart/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/cell-protection/main.go
+++ b/spreadsheet/cell-protection/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/spreadsheet"
-	"github.com/unidoc/unioffice/spreadsheet/reference"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
+	"github.com/unidoc/unioffice/v2/spreadsheet/reference"
 )
 
 func init() {

--- a/spreadsheet/cells-with-empty/main.go
+++ b/spreadsheet/cells-with-empty/main.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/comments/main.go
+++ b/spreadsheet/comments/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/complex/main.go
+++ b/spreadsheet/complex/main.go
@@ -7,13 +7,13 @@ import (
 	"math/rand"
 	"os"
 
-	"github.com/unidoc/unioffice/chart"
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/chart"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 
-	"github.com/unidoc/unioffice/schema/soo/sml"
+	"github.com/unidoc/unioffice/v2/schema/soo/sml"
 )
 
 func init() {

--- a/spreadsheet/conditional-formatting/main.go
+++ b/spreadsheet/conditional-formatting/main.go
@@ -6,10 +6,10 @@ import (
 	"math/rand"
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/schema/soo/sml"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/schema/soo/sml"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/convert_to_pdf/main.go
+++ b/spreadsheet/convert_to_pdf/main.go
@@ -1,5 +1,6 @@
 // Copyright 2017 FoxyUtils ehf. All rights reserved.
 package main
+
 // This example demonstrates converting a workbook to a PDF file.
 
 import (
@@ -7,9 +8,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
-	"github.com/unidoc/unioffice/spreadsheet/convert"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
+	"github.com/unidoc/unioffice/v2/spreadsheet/convert"
 	pdflicense "github.com/unidoc/unipdf/v3/common/license"
 )
 

--- a/spreadsheet/flatten/main.go
+++ b/spreadsheet/flatten/main.go
@@ -10,9 +10,9 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
-	"github.com/unidoc/unioffice/spreadsheet/formula"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
+	"github.com/unidoc/unioffice/v2/spreadsheet/formula"
 )
 
 func init() {

--- a/spreadsheet/formula-evaluation/main.go
+++ b/spreadsheet/formula-evaluation/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
-	"github.com/unidoc/unioffice/spreadsheet/formula"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
+	"github.com/unidoc/unioffice/v2/spreadsheet/formula"
 )
 
 func init() {

--- a/spreadsheet/formula/main.go
+++ b/spreadsheet/formula/main.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/schema/soo/sml"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/schema/soo/sml"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/freeze-rows-cols/main.go
+++ b/spreadsheet/freeze-rows-cols/main.go
@@ -6,8 +6,8 @@ import (
 	"math/rand"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/image/main.go
+++ b/spreadsheet/image/main.go
@@ -6,10 +6,10 @@ import (
 	"math"
 	"os"
 
-	"github.com/unidoc/unioffice/common"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/measurement"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/insert-rows/main.go
+++ b/spreadsheet/insert-rows/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/line-chart-3d/main.go
+++ b/spreadsheet/line-chart-3d/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/line-chart-from-csv/main.go
+++ b/spreadsheet/line-chart-from-csv/main.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/line-chart-no-data/main.go
+++ b/spreadsheet/line-chart-no-data/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/line-chart/main.go
+++ b/spreadsheet/line-chart/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/lots-of-rows/main.go
+++ b/spreadsheet/lots-of-rows/main.go
@@ -9,8 +9,8 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/merged/main.go
+++ b/spreadsheet/merged/main.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 
-	"github.com/unidoc/unioffice/schema/soo/sml"
+	"github.com/unidoc/unioffice/v2/schema/soo/sml"
 )
 
 func init() {

--- a/spreadsheet/multiple-charts-from-csv/main.go
+++ b/spreadsheet/multiple-charts-from-csv/main.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/multiple-charts/main.go
+++ b/spreadsheet/multiple-charts/main.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/chart"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/chart"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/named-cells/main.go
+++ b/spreadsheet/named-cells/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/named-ranges/main.go
+++ b/spreadsheet/named-ranges/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/number-date-time-formats/main.go
+++ b/spreadsheet/number-date-time-formats/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/pie-chart/main.go
+++ b/spreadsheet/pie-chart/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/radar-chart/main.go
+++ b/spreadsheet/radar-chart/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/references-with-sheet-name/main.go
+++ b/spreadsheet/references-with-sheet-name/main.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet/reference"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet/reference"
 )
 
 func init() {

--- a/spreadsheet/remove-column/main.go
+++ b/spreadsheet/remove-column/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/rich-text/main.go
+++ b/spreadsheet/rich-text/main.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/color"
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/color"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {
@@ -32,7 +32,7 @@ func main() {
 		// and cells
 		for c := 0; c < 5; c++ {
 			cell := row.AddCell()
-			//cell.SetString(fmt.Sprintf("row %d cell %d", r, c))
+			// cell.SetString(fmt.Sprintf("row %d cell %d", r, c))
 			rt := cell.SetRichTextString()
 			run := rt.AddRun()
 			run.SetText(fmt.Sprintf("row %d ", r))

--- a/spreadsheet/rotated-cells/main.go
+++ b/spreadsheet/rotated-cells/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/shared-formula/main.go
+++ b/spreadsheet/shared-formula/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/simple/main.go
+++ b/spreadsheet/simple/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/sort-filter/main.go
+++ b/spreadsheet/sort-filter/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/surface-chart/main.go
+++ b/spreadsheet/surface-chart/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/text_extraction/main.go
+++ b/spreadsheet/text_extraction/main.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {
@@ -53,32 +53,36 @@ func main() {
 			}
 			style := cellStyles[*cellX.SAttr]
 			font := style.GetFont()
-			if font.B != nil {
-				fmt.Println("Bold")
+			for _, fc := range font.FontChoice {
+				if fc.B != nil {
+					fmt.Println("Bold")
+				}
+				if fc.I != nil {
+					fmt.Println("Italic")
+				}
+				if fc.Color != nil {
+					fontColor := fc.Color
+					if fontColor == nil {
+						panic("expected font color to be non-nil")
+					}
+					fmt.Println("Font color theme:", *fontColor.ThemeAttr)
+					fmt.Println("Font color tint:", *fontColor.TintAttr)
+				}
 			}
-			if font.I != nil {
-				fmt.Println("Italic")
-			}
-			if len(font.Color) == 0 {
-				panic("expected font to have a color")
-			}
-			fontColor := font.Color[0]
-			if fontColor == nil {
-				panic("expected font color to be non-nil")
-			}
-			fmt.Println("Font color theme:", *fontColor.ThemeAttr)
-			fmt.Println("Font color tint:", *fontColor.TintAttr)
+
 			fill := style.GetFill()
-			patternFill := fill.PatternFill
-			if patternFill == nil {
-				panic("expected pattern fill to be non-nil")
+			if fc := fill.FillChoice; fc != nil {
+				patternFill := fc.PatternFill
+				if patternFill == nil {
+					panic("expected pattern fill to be non-nil")
+				}
+				cellColor := patternFill.FgColor
+				if cellColor == nil {
+					panic("expected foreground color to be non-nil")
+				}
+				fmt.Println("Cell color theme:", *cellColor.ThemeAttr)
+				fmt.Println("Cell color tint:", *cellColor.TintAttr)
 			}
-			cellColor := patternFill.FgColor
-			if cellColor == nil {
-				panic("expected foreground color to be non-nil")
-			}
-			fmt.Println("Cell color theme:", *cellColor.ThemeAttr)
-			fmt.Println("Cell color tint:", *cellColor.TintAttr)
 		}
 	}
 }

--- a/spreadsheet/validation/main.go
+++ b/spreadsheet/validation/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {

--- a/spreadsheet/wrapped-text/main.go
+++ b/spreadsheet/wrapped-text/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/unidoc/unioffice/common/license"
-	"github.com/unidoc/unioffice/spreadsheet"
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/spreadsheet"
 )
 
 func init() {


### PR DESCRIPTION
This pull request updates the import paths to use version 2 of the `unioffice` package across multiple files. Additionally, it includes a minor change to the `doc-custom-properties` file to update the usage of property choice fields.

### Import Path Updates:
* [`document/bullet-and-numbering/main.go`](diffhunk://#diff-405513a360cd33e4495280e646e736f4f1dbc4e5bf992b1c19a4a4c3e1f3d8b0L8-R11): Updated import paths to use `unioffice/v2`.
* [`document/chart/main.go`](diffhunk://#diff-65919821da6b182a1d7018672892345886123b543f5870d7a1a188063ca56b23L12-R22): Updated import paths to use `unioffice/v2`.
* [`document/convert_to_pdf/main.go`](diffhunk://#diff-5f3686d585253428a4185a5cf04a5acc10bcaeef5ee21dc3525ba926e4a46a1cL14-R16): Updated import paths to use `unioffice/v2`.
* [`document/convert_to_pdf_fonts/main.go`](diffhunk://#diff-57849dfebd31d6515ea977a00a9de2400e978803e5a5c87e66486013e94a5699L15-R17): Updated import paths to use `unioffice/v2`.
* [`document/convert_to_pdf_options/main.go`](diffhunk://#diff-aa71cbfa92eb994dba7720de9f8464b118802cd5f481cda55253da46b3e16481L14-R16): Updated import paths to use `unioffice/v2`.
* [`document/doc-custom-properties/main.go`](diffhunk://#diff-2062cb090c23b5970dc9b2ffd53d9b457a7f68b08169e729ef4d11d048ed7d71L11-R12): Updated import paths to use `unioffice/v2`.
* [`document/doc-existing-header/main.go`](diffhunk://#diff-c37090fc03a12cceda245b0f3d0586337d201ac2008a77470b93c47ebfab8313L9-R11): Updated import paths to use `unioffice/v2`.
* [`document/doc-properties/main.go`](diffhunk://#diff-d4a58a849d7079365d98f8a87fcc63f001cfd5b49283c51d5e4e9c614d22b6e7L11-R12): Updated import paths to use `unioffice/v2`.
* [`document/doc-to-pdf-fonts/main.go`](diffhunk://#diff-57849dfebd31d6515ea977a00a9de2400e978803e5a5c87e66486013e94a5699L15-R17): Updated import paths to use `unioffice/v2`.
* [`document/doc-to-pdf/main.go`](diffhunk://#diff-b81fd7baea240406576c7a89c9f4756ddbf48bd7670d56069ce1050929997914L14-R16): Updated import paths to use `unioffice/v2`.
* [`document/edit-document/main.go`](diffhunk://#diff-8b165ac27ba0d009b0cdc82dd323b2856525fe414f1cce16a323e19db6d71d13L11-R12): Updated import paths to use `unioffice/v2`.
* [`document/endnotes_footnotes/main.go`](diffhunk://#diff-1d62ba0ea1f200dcca44e2e77c4ccba8d300b76760bdeec3d2af3a6c3e61ab34L10-R11): Updated import paths to use `unioffice/v2`.
* [`document/endnotes_footnotes_insert/main.go`](diffhunk://#diff-f28460d2868abc9e1cb3ddd532d8ef0a4613b75c4a503de8dd12209d09c7851fR6-R16): Updated import paths to use `unioffice/v2` and improved error handling.
* [`document/endnotes_footnotes_remove/main.go`](diffhunk://#diff-7180bfaa85670acc55db5242c28cbdecab1869a82f763270e3f7bb43a09d77e2L9-R10): Updated import paths to use `unioffice/v2`.
* [`document/even-odd-header/main.go`](diffhunk://#diff-7de7313caae81164dec53272b2bbfc9a1975ddd46cf5fc662c015631c2ab00afL12-R15): Updated import paths to use `unioffice/v2`.
* [`document/fill-out-form/main.go`](diffhunk://#diff-e998839d6bd7322de158836e266593cf22c36b9a345a8ba09a435d7a2617eb9fL9-R10): Updated import paths to use `unioffice/v2`.
* [`document/form-activex/main.go`](diffhunk://#diff-d21dc32eb6473e61d3157f25737d516c996bbfb7ea2bf33716f27cc65653908bL12-R13): Updated import paths to use `unioffice/v2`.
* [`document/form-fields/main.go`](diffhunk://#diff-fbee9be52a2467ff8046b685692f5573f89744bcd5ddbb65535b95a6cb818b30L8-R9): Updated import paths to use `unioffice/v2`.
* [`document/header-footer-multiple/main.go`](diffhunk://#diff-968632fc5ccb368d17e21ad98d1fa1927e0fd5dfa8a92acf8bc638f15aa458caL7-R10): Updated import paths to use `unioffice/v2`.
* [`document/header-footer/main.go`](diffhunk://#diff-5b4d7ce7a086d6388afaf7b1fdc2f6478ad097023fcdf8d950ffe864f4b20583L9-R13): Updated import paths to use `unioffice/v2`.

### Property Choice Fields Update:
* [`document/doc-custom-properties/main.go`](diffhunk://#diff-2062cb090c23b5970dc9b2ffd53d9b457a7f68b08169e729ef4d11d048ed7d71L34-R42): Updated usage of property choice fields in `GetPropertyByName` method calls.