### PR TITLE
[US-1664] Presentation examples for animations and speaker notes.

### DIFF
--- a/presentation/animations/main.go
+++ b/presentation/animations/main.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 FoxyUtils ehf. All rights reserved.
+ *
+ * This example demonstrates click-triggered entrance animations on slide
+ * shapes: each click during the slide show reveals or animates in one more
+ * shape, instead of showing everything on the slide at once.
+ */
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/measurement"
+	"github.com/unidoc/unioffice/v2/presentation"
+)
+
+func init() {
+	// Make sure to load your metered License API key prior to using the library.
+	// If you need a key, you can sign up and create a free one at https://cloud.unidoc.io
+	err := license.SetMeteredKey(os.Getenv(`UNIDOC_LICENSE_API_KEY`))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	ppt := presentation.New()
+	defer ppt.Close()
+
+	slide := ppt.AddSlide()
+
+	title := slide.AddTextBox()
+	title.AddParagraph().AddRun().SetText("Quarterly Highlights")
+	title.Properties().SetPosition(0.5*measurement.Inch, 0.5*measurement.Inch)
+	title.Properties().SetWidth(6 * measurement.Inch)
+
+	// Animations returns the slide's main click-driven animation sequence,
+	// creating the timing scaffold on first use. Every AddOnClickEntrance
+	// call below appends one more click step to it.
+	seq := slide.Animations()
+
+	// Reveal the bullet points one at a time: each gets its own entrance, so
+	// the next one only appears on the next click instead of all at once.
+	bullets := []string{
+		"Revenue is up 12% year over year",
+		"Two new markets launched",
+		"Support tickets down 30%",
+	}
+	for i, text := range bullets {
+		tb := slide.AddTextBox()
+		tb.AddParagraph().AddRun().SetText(text)
+		tb.Properties().SetPosition(0.5*measurement.Inch, measurement.Distance(2+i)*measurement.Inch)
+		tb.Properties().SetWidth(6 * measurement.Inch)
+
+		seq.AddOnClickEntrance(tb, presentation.EntranceAppear)
+	}
+
+	// The other entrance effects animate the shape in rather than just
+	// revealing it: EntranceFade brings it in via opacity, EntranceFlyIn
+	// slides it in from the bottom of the slide.
+	callout := slide.AddTextBox()
+	callout.AddParagraph().AddRun().SetText("Ask us about the new pricing tiers")
+	callout.Properties().SetPosition(0.5*measurement.Inch, 5.5*measurement.Inch)
+	callout.Properties().SetWidth(6 * measurement.Inch)
+	seq.AddOnClickEntrance(callout, presentation.EntranceFlyIn)
+
+	closing := slide.AddTextBox()
+	closing.AddParagraph().AddRun().SetText("Thank you")
+	closing.Properties().SetPosition(0.5*measurement.Inch, 6.5*measurement.Inch)
+	closing.Properties().SetWidth(6 * measurement.Inch)
+	seq.AddOnClickEntrance(closing, presentation.EntranceFade)
+
+	if err := ppt.Validate(); err != nil {
+		log.Fatal(err)
+	}
+	ppt.SaveToFile("animations.pptx")
+}

--- a/presentation/speaker-notes/main.go
+++ b/presentation/speaker-notes/main.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 FoxyUtils ehf. All rights reserved.
+ *
+ * This example demonstrates speaker notes: per-slide presenter-only text that
+ * appears in PowerPoint's Notes pane and presenter view, not on the slide
+ * itself.
+ */
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/unidoc/unioffice/v2/common/license"
+	"github.com/unidoc/unioffice/v2/presentation"
+)
+
+func init() {
+	// Make sure to load your metered License API key prior to using the library.
+	// If you need a key, you can sign up and create a free one at https://cloud.unidoc.io
+	err := license.SetMeteredKey(os.Getenv(`UNIDOC_LICENSE_API_KEY`))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	ppt := presentation.New()
+	defer ppt.Close()
+
+	intro := ppt.AddSlide()
+	intro.AddTextBox().AddParagraph().AddRun().SetText("Welcome")
+	// EnsureNotes creates the notes part (and a notes master, if the
+	// presentation has none yet) on first use, and is safe to call again -
+	// it returns the same notes every time.
+	intro.EnsureNotes().SetText("Greet the audience and introduce the topic before advancing.")
+
+	agenda := ppt.AddSlide()
+	agenda.AddTextBox().AddParagraph().AddRun().SetText("Agenda")
+	// A multi-paragraph note: SetText replaces the notes with a single
+	// paragraph, and AddParagraph appends one more line after it.
+	agendaNotes := agenda.EnsureNotes()
+	agendaNotes.SetText("Cover three points today:")
+	agendaNotes.AddParagraph().AddRun().SetText("1. What changed")
+	agendaNotes.AddParagraph().AddRun().SetText("2. Why it matters")
+	agendaNotes.AddParagraph().AddRun().SetText("3. What's next")
+
+	// This slide is left without notes, to show GetNotes reporting none below.
+	closing := ppt.AddSlide()
+	closing.AddTextBox().AddParagraph().AddRun().SetText("Questions?")
+
+	if err := ppt.Validate(); err != nil {
+		log.Fatal(err)
+	}
+	ppt.SaveToFile("speaker-notes.pptx")
+
+	// GetNotes reports whether a slide has notes at all, without creating
+	// them - unlike EnsureNotes, it never modifies the slide.
+	for i, slide := range ppt.Slides() {
+		notes, ok := slide.GetNotes()
+		if !ok {
+			fmt.Printf("Slide %d: no notes\n", i+1)
+			continue
+		}
+		fmt.Printf("Slide %d notes:\n%s\n\n", i+1, notes.Text())
+	}
+}


### PR DESCRIPTION
JIRA: https://unidoc.atlassian.net/browse/US-1664

The PR adds two new presentation examples showcasing UniOffice's latest release functionality: 

- presentation/animations/main.go demonstrates click-triggered entrance animations (Slide.Animations() / AnimationSequence.AddOnClickEntrance), building a slide that reveals bullet points one click at a time and showcases the fade and fly-in entrance effects
- presentation/speaker-notes/main.go demonstrates the new speaker notes API (Slide.EnsureNotes, Slide.GetNotes, Notes.SetText/AddParagraph/Text), covering single-line notes, multi-paragraph notes, and a slide deliberately left without notes to show GetNotes reporting none. 